### PR TITLE
Support version-aware copy sources

### DIFF
--- a/src/api/object.rs
+++ b/src/api/object.rs
@@ -139,21 +139,43 @@ pub async fn put_object(
     Ok(builder.body(Body::empty()).unwrap())
 }
 
-/// Parse the `x-amz-copy-source` header into (src_bucket, src_key).
-fn parse_copy_source(headers: &HeaderMap) -> Result<(String, String), S3Error> {
+struct CopySource {
+    bucket: String,
+    key: String,
+    version_id: Option<String>,
+}
+
+/// Parse the `x-amz-copy-source` header into bucket/key and optional versionId.
+fn parse_copy_source(headers: &HeaderMap) -> Result<CopySource, S3Error> {
     let copy_source = headers
         .get("x-amz-copy-source")
         .and_then(|v| v.to_str().ok())
         .ok_or_else(|| S3Error::invalid_argument("missing x-amz-copy-source header"))?;
 
-    let decoded = percent_encoding::percent_decode_str(copy_source)
+    let (raw_path, raw_query) = copy_source.split_once('?').unwrap_or((copy_source, ""));
+    let version_id = raw_query.split('&').find_map(|pair| {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if key != "versionId" {
+            return None;
+        }
+        percent_encoding::percent_decode_str(value)
+            .decode_utf8()
+            .ok()
+            .map(|value| value.into_owned())
+    });
+
+    let decoded = percent_encoding::percent_decode_str(raw_path)
         .decode_utf8()
         .map_err(|_| S3Error::invalid_argument("invalid x-amz-copy-source encoding"))?;
     let trimmed = decoded.trim_start_matches('/');
     let (src_bucket, src_key) = trimmed
         .split_once('/')
         .ok_or_else(|| S3Error::invalid_argument("invalid x-amz-copy-source format"))?;
-    Ok((src_bucket.to_string(), src_key.to_string()))
+    Ok(CopySource {
+        bucket: src_bucket.to_string(),
+        key: src_key.to_string(),
+        version_id,
+    })
 }
 
 /// Parse `x-amz-copy-source-range: bytes=start-end` into (start, end) inclusive.
@@ -189,7 +211,10 @@ async fn upload_part_copy(
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Result<Response<Body>, S3Error> {
-    let (src_bucket, src_key) = parse_copy_source(&headers)?;
+    let copy_source = parse_copy_source(&headers)?;
+    let src_bucket = copy_source.bucket;
+    let src_key = copy_source.key;
+    let src_version_id = copy_source.version_id;
 
     let upload_id = params
         .get("uploadId")
@@ -203,40 +228,78 @@ async fn upload_part_copy(
     multipart::ensure_bucket_exists(&state, &bucket).await?;
 
     // Get source metadata first to validate range before opening the file
-    let src_meta = state
-        .storage
-        .head_object(&src_bucket, &src_key)
-        .await
-        .map_err(|e| match e {
-            StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
-            _ => S3Error::internal(e),
-        })?;
+    let src_meta = if let Some(version_id) = src_version_id.as_deref() {
+        state
+            .storage
+            .head_object_version(&src_bucket, &src_key, version_id)
+            .await
+            .map_err(|e| match e {
+                StorageError::VersionNotFound(_) => S3Error::no_such_version(version_id),
+                StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
+                _ => S3Error::internal(e),
+            })?
+    } else {
+        state
+            .storage
+            .head_object(&src_bucket, &src_key)
+            .await
+            .map_err(|e| match e {
+                StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
+                _ => S3Error::internal(e),
+            })?
+    };
 
     let range = parse_copy_source_range(&headers, src_meta.size)?;
 
     let reader = match range {
         None => {
-            let (r, _) = state
-                .storage
-                .get_object(&src_bucket, &src_key)
-                .await
-                .map_err(|e| match e {
-                    StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
-                    StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
-                    _ => S3Error::internal(e),
-                })?;
+            let (r, _) = if let Some(version_id) = src_version_id.as_deref() {
+                state
+                    .storage
+                    .get_object_version(&src_bucket, &src_key, version_id)
+                    .await
+                    .map_err(|e| match e {
+                        StorageError::VersionNotFound(_) => S3Error::no_such_version(version_id),
+                        StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
+                        StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
+                        _ => S3Error::internal(e),
+                    })?
+            } else {
+                state
+                    .storage
+                    .get_object(&src_bucket, &src_key)
+                    .await
+                    .map_err(|e| match e {
+                        StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
+                        StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
+                        _ => S3Error::internal(e),
+                    })?
+            };
             r
         }
         Some((start, end)) => {
-            let (r, _) = state
-                .storage
-                .get_object_range(&src_bucket, &src_key, start, end - start + 1)
-                .await
-                .map_err(|e| match e {
-                    StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
-                    StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
-                    _ => S3Error::internal(e),
-                })?;
+            let (r, _) = if let Some(version_id) = src_version_id.as_deref() {
+                state
+                    .storage
+                    .get_object_version_range(&src_bucket, &src_key, version_id, start, end - start + 1)
+                    .await
+                    .map_err(|e| match e {
+                        StorageError::VersionNotFound(_) => S3Error::no_such_version(version_id),
+                        StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
+                        StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
+                        _ => S3Error::internal(e),
+                    })?
+            } else {
+                state
+                    .storage
+                    .get_object_range(&src_bucket, &src_key, start, end - start + 1)
+                    .await
+                    .map_err(|e| match e {
+                        StorageError::NotFound(_) => S3Error::no_such_key(&src_key),
+                        StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
+                        _ => S3Error::internal(e),
+                    })?
+            };
             r
         }
     };
@@ -266,7 +329,10 @@ async fn copy_object(
     Path((bucket, key)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> Result<Response<Body>, S3Error> {
-    let (src_bucket, src_key) = parse_copy_source(&headers)?;
+    let copy_source = parse_copy_source(&headers)?;
+    let src_bucket = copy_source.bucket;
+    let src_key = copy_source.key;
+    let src_version_id = copy_source.version_id;
     let (src_bucket, src_key) = (src_bucket.as_str(), src_key.as_str());
 
     // Validate destination bucket
@@ -277,15 +343,28 @@ async fn copy_object(
     }
 
     // Get source object
-    let (reader, src_meta) = state
-        .storage
-        .get_object(src_bucket, src_key)
-        .await
-        .map_err(|e| match e {
-            StorageError::NotFound(_) => S3Error::no_such_key(src_key),
-            StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
-            _ => S3Error::internal(e),
-        })?;
+    let (reader, src_meta) = if let Some(version_id) = src_version_id.as_deref() {
+        state
+            .storage
+            .get_object_version(src_bucket, src_key, version_id)
+            .await
+            .map_err(|e| match e {
+                StorageError::VersionNotFound(_) => S3Error::no_such_version(version_id),
+                StorageError::NotFound(_) => S3Error::no_such_key(src_key),
+                StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
+                _ => S3Error::internal(e),
+            })?
+    } else {
+        state
+            .storage
+            .get_object(src_bucket, src_key)
+            .await
+            .map_err(|e| match e {
+                StorageError::NotFound(_) => S3Error::no_such_key(src_key),
+                StorageError::InvalidKey(msg) => S3Error::invalid_argument(&msg),
+                _ => S3Error::internal(e),
+            })?
+    };
 
     // Determine content-type based on metadata directive
     let directive = headers

--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -1737,6 +1737,72 @@ impl FilesystemStorage {
         Ok((Box::pin(BufReader::with_capacity(IO_BUFFER_SIZE, file)), meta))
     }
 
+    pub async fn get_object_version_range(
+        &self,
+        bucket: &str,
+        key: &str,
+        version_id: &str,
+        offset: u64,
+        length: u64,
+    ) -> Result<(ByteStream, ObjectMeta), StorageError> {
+        validate_key(key)?;
+        let ver_meta_path = self.version_meta_path(bucket, key, version_id);
+        let data = fs::read_to_string(&ver_meta_path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StorageError::VersionNotFound(version_id.to_string())
+            } else {
+                StorageError::Io(e)
+            }
+        })?;
+        let meta: ObjectMeta = serde_json::from_str(&data)?;
+
+        if meta.is_delete_marker {
+            return Err(StorageError::NotFound(key.to_string()));
+        }
+
+        let ver_ec_dir = self.versions_dir(bucket, key).join(format!("{}.ec", version_id));
+        if ver_ec_dir.is_dir() {
+            let manifest_path = ver_ec_dir.join("manifest.json");
+            let manifest_data = fs::read_to_string(&manifest_path).await.map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    StorageError::VersionNotFound(version_id.to_string())
+                } else {
+                    StorageError::Io(e)
+                }
+            })?;
+            let manifest: ChunkManifest = serde_json::from_str(&manifest_data)?;
+            let reader = VerifiedChunkReader::with_range(ver_ec_dir, manifest, offset, length);
+            return Ok((Box::pin(reader), meta));
+        }
+
+        let ver_data_path = self.version_data_path(bucket, key, version_id);
+        if length <= SMALL_OBJECT_THRESHOLD {
+            let mut file = fs::File::open(&ver_data_path).await.map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    StorageError::VersionNotFound(version_id.to_string())
+                } else {
+                    StorageError::Io(e)
+                }
+            })?;
+            file.seek(std::io::SeekFrom::Start(offset)).await.map_err(StorageError::Io)?;
+            let mut data = vec![0u8; length as usize];
+            file.read_exact(&mut data).await.map_err(StorageError::Io)?;
+            return Ok((Box::pin(std::io::Cursor::new(data)), meta));
+        }
+
+        let mut file = fs::File::open(&ver_data_path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StorageError::VersionNotFound(version_id.to_string())
+            } else {
+                StorageError::Io(e)
+            }
+        })?;
+        file.seek(std::io::SeekFrom::Start(offset)).await.map_err(StorageError::Io)?;
+        let limited = file.take(length);
+        let reader = BufReader::with_capacity(IO_BUFFER_SIZE, limited);
+        Ok((Box::pin(reader), meta))
+    }
+
     pub async fn head_object_version(
         &self,
         bucket: &str,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -472,6 +472,16 @@ fn extract_xml_tag(body: &str, tag: &str) -> Option<String> {
     Some(body[from..to].to_string())
 }
 
+async fn enable_bucket_versioning(base_url: &str, bucket: &str) -> reqwest::Response {
+    let xml = br#"<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>"#;
+    s3_request(
+        "PUT",
+        &format!("{}/{}?versioning=", base_url, bucket),
+        xml.to_vec(),
+    )
+    .await
+}
+
 
 // ---- Tests ----
 
@@ -1523,6 +1533,55 @@ async fn test_copy_object_no_leading_slash() {
 
     let resp = s3_request("GET", &format!("{}/mybucket/dst.txt", base_url), vec![]).await;
     assert_eq!(resp.bytes().await.unwrap().as_ref(), b"no slash");
+}
+
+#[tokio::test]
+async fn test_copy_object_specific_source_version() {
+    let (base_url, _tmp) = start_server().await;
+    s3_request("PUT", &format!("{}/src-bucket", base_url), vec![]).await;
+    s3_request("PUT", &format!("{}/dst-bucket", base_url), vec![]).await;
+    assert_eq!(
+        enable_bucket_versioning(&base_url, "src-bucket").await.status(),
+        200
+    );
+
+    let v1_body = b"old version".to_vec();
+    let put_v1 = s3_request(
+        "PUT",
+        &format!("{}/src-bucket/file.txt", base_url),
+        v1_body.clone(),
+    )
+    .await;
+    let version_id_v1 = put_v1
+        .headers()
+        .get("x-amz-version-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    s3_request(
+        "PUT",
+        &format!("{}/src-bucket/file.txt", base_url),
+        b"new version".to_vec(),
+    )
+    .await;
+
+    let resp = s3_request_with_headers(
+        "PUT",
+        &format!("{}/dst-bucket/copied.txt", base_url),
+        vec![],
+        vec![(
+            "x-amz-copy-source",
+            &format!("/src-bucket/file.txt?versionId={}", version_id_v1),
+        )],
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+
+    let get = s3_request("GET", &format!("{}/dst-bucket/copied.txt", base_url), vec![]).await;
+    assert_eq!(get.status(), 200);
+    assert_eq!(get.bytes().await.unwrap().as_ref(), v1_body.as_slice());
 }
 
 /// Generate a presigned URL for the given method/path.
@@ -3048,6 +3107,73 @@ async fn test_upload_part_copy_range() {
     let get = s3_request("GET", &format!("{}/dst-upcr/dest.bin", base), vec![]).await;
     assert_eq!(get.status(), 200);
     assert_eq!(get.bytes().await.unwrap().as_ref(), src_data.as_slice());
+}
+
+#[tokio::test]
+async fn test_upload_part_copy_specific_source_version() {
+    let (base, _tmp) = start_server().await;
+
+    s3_request("PUT", &format!("{}/src-upcv", base), vec![]).await;
+    s3_request("PUT", &format!("{}/dst-upcv", base), vec![]).await;
+    assert_eq!(
+        enable_bucket_versioning(&base, "src-upcv").await.status(),
+        200
+    );
+
+    let source_v1 = vec![b'A'; 5 * 1024 * 1024];
+    let put_v1 = s3_request(
+        "PUT",
+        &format!("{}/src-upcv/source.bin", base),
+        source_v1.clone(),
+    )
+    .await;
+    let version_id_v1 = put_v1
+        .headers()
+        .get("x-amz-version-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    s3_request(
+        "PUT",
+        &format!("{}/src-upcv/source.bin", base),
+        vec![b'B'; 5 * 1024 * 1024],
+    )
+    .await;
+
+    let create = s3_request("POST", &format!("{}/dst-upcv/dest.bin?uploads=", base), vec![]).await;
+    let upload_id = extract_xml_tag(&create.text().await.unwrap(), "UploadId").unwrap();
+
+    let resp = s3_request_with_headers(
+        "PUT",
+        &format!("{}/dst-upcv/dest.bin?partNumber=1&uploadId={}", base, upload_id),
+        vec![],
+        vec![(
+            "x-amz-copy-source",
+            &format!("/src-upcv/source.bin?versionId={}", version_id_v1),
+        )],
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    let etag = extract_xml_tag(&body, "ETag").unwrap();
+
+    let complete_xml = format!(
+        "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>{}</ETag></Part></CompleteMultipartUpload>",
+        etag
+    );
+    let complete = s3_request(
+        "POST",
+        &format!("{}/dst-upcv/dest.bin?uploadId={}", base, upload_id),
+        complete_xml.into_bytes(),
+    )
+    .await;
+    assert_eq!(complete.status(), 200);
+
+    let get = s3_request("GET", &format!("{}/dst-upcv/dest.bin", base), vec![]).await;
+    assert_eq!(get.status(), 200);
+    assert_eq!(get.bytes().await.unwrap().as_ref(), source_v1.as_slice());
 }
 
 // ---- CORS API tests ----


### PR DESCRIPTION
## Summary
- parse optional `versionId` values from `x-amz-copy-source`
- allow `CopyObject` and `UploadPartCopy` to read a specific source version
- add regression coverage for version-aware copy behavior

## Why
Copy requests treated `/bucket/key?versionId=...` as part of the object key, so copy operations could only read the latest object version.

## Impact
`CopyObject` and `UploadPartCopy` can now target historical source versions in versioned buckets.

## Validation
- `cargo test test_copy_object_specific_source_version -- --exact`
- `cargo test test_upload_part_copy_specific_source_version -- --exact`
- `cargo test copy_object`
- `cargo test upload_part_copy`