### PR TITLE
feat(ui): migrate to Geist font and add UI component primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,9 +265,9 @@ The web console (`ui/`) follows the Coolify design system. The full specificatio
 - **Stack**: Svelte 5, Vite, Tailwind CSS v4, shadcn-svelte components
 - **Theme**: Class-based dark mode (`.dark` on `<html>`), with light/dark CSS variable swap in `ui/src/app.css`
 - **Accent colors**: Coollabs purple `#6b16ed` (light) / warning yellow `#fcd452` (dark). Brand purple (`--color-brand`) is always `#6b16ed` regardless of theme
-- **Font**: Inter (Google Fonts)
+- **Font**: Geist Sans + Geist Mono via `@fontsource/geist-sans` / `@fontsource/geist-mono` (Inter fallback)
 - **Inputs**: Inset box-shadow system (4px colored left bar on focus), no standard borders — see `.input-cool` in `app.css`
-- **Buttons**: `border-2`, `h-8`, `rounded-sm`. Variants: `default`, `destructive`, `outline`, `secondary`, `ghost`, `link`, `brand`
+- **Buttons**: `border-2`, `h-8`, `rounded-sm`. Variants: `default`, `highlighted`, `destructive`, `outline`, `secondary`, `ghost`, `link`, `brand`
 - **Border radius**: `0.125rem` (2px) everywhere — set via `--radius` in `@theme inline`
 - **Sidebar**: Collapsible 224px → 56px icon-only, uses `--cool-sidebar-*` CSS variables
 

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "ui",
       "dependencies": {
+        "@fontsource/geist-mono": "^5.2.5",
+        "@fontsource/geist-sans": "^5.2.5",
         "bits-ui": "^2.15.7",
         "clsx": "^2.1.1",
         "lucide-svelte": "^0.574.0",
@@ -83,6 +85,10 @@
     "@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.7", "", {}, "sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg=="],
+
+    "@fontsource/geist-sans": ["@fontsource/geist-sans@5.2.5", "", {}, "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A=="],
 
     "@internationalized/date": ["@internationalized/date@3.11.0", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q=="],
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,12 +5,6 @@
     <link rel="icon" type="image/png" href="/ui/maxio.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MaxIO</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div id="app"></div>

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "bits-ui": "^2.15.7",
+    "@fontsource/geist-mono": "^5.2.5",
+    "@fontsource/geist-sans": "^5.2.5",
     "clsx": "^2.1.1",
     "lucide-svelte": "^0.574.0",
     "svelte-sonner": "^1.0.7",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -181,14 +181,13 @@
       <div class="flex flex-1 flex-col gap-0.5 p-2">
         <button
           onclick={goHome}
-          class="flex h-9 w-full items-center rounded-sm text-left text-sm font-medium transition-colors overflow-hidden"
+          class="flex h-9 w-full items-center rounded-sm text-left text-sm font-medium transition-colors overflow-hidden bg-neutral-200 text-black dark:bg-coolgray-200 dark:text-warning hover:bg-neutral-300 dark:hover:bg-coolgray-100"
           class:gap-3={!collapsed}
           class:px-3={!collapsed}
           class:justify-center={collapsed}
-          style="background: var(--cool-sidebar-active-bg); color: var(--cool-sidebar-active-fg);"
           title="Buckets"
         >
-          <Home class="size-4 shrink-0" />
+          <Home class="size-6 shrink-0" />
           {#if !collapsed}<span class="whitespace-nowrap">Buckets</span>{/if}
         </button>
       </div>

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+@import "@fontsource/geist-sans/400.css";
+@import "@fontsource/geist-sans/500.css";
+@import "@fontsource/geist-sans/600.css";
+@import "@fontsource/geist-sans/700.css";
+@import "@fontsource/geist-mono/400.css";
+@import "@fontsource/geist-mono/500.css";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* ==============================================
    COOLIFY DESIGN TOKENS
    Light mode = :root, Dark mode = .dark on <html>
@@ -91,6 +100,7 @@
   --color-destructive-foreground: #ffffff;
 
   --color-success: var(--cool-success);
+  --color-error: var(--cool-error);
 
   /* Brand — always coollabs purple, does not swap with dark mode */
   --color-brand: #6b16ed;
@@ -114,12 +124,40 @@
   --color-sidebar-active: var(--cool-sidebar-active-bg);
   --color-sidebar-active-foreground: var(--cool-sidebar-active-fg);
 
+  /* Coollabs (brand) scale */
+  --color-coollabs: #6b16ed;
+  --color-coollabs-50: #f5f0ff;
+  --color-coollabs-100: #7317ff;
+  --color-coollabs-200: #5a12c7;
+  --color-coollabs-300: #4a0fa3;
+
+  /* Warning scale — used for dark-mode accent + callouts */
+  --color-warning: #fcd452;
+  --color-warning-50: #fefce8;
+  --color-warning-100: #fef9c3;
+  --color-warning-200: #fef08a;
+  --color-warning-300: #fde047;
+  --color-warning-400: #fcd452;
+  --color-warning-500: #facc15;
+  --color-warning-600: #ca8a04;
+  --color-warning-700: #a16207;
+  --color-warning-800: #854d0e;
+  --color-warning-900: #713f12;
+
+  /* Coolgray scale — dark mode background hierarchy */
+  --color-base: #101010;
+  --color-coolgray-100: #181818;
+  --color-coolgray-200: #202020;
+  --color-coolgray-300: #242424;
+  --color-coolgray-400: #282828;
+  --color-coolgray-500: #323232;
+
   --radius: 0.125rem;
 
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+  --font-sans: "Geist", "Geist Sans", Inter, ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 }
 
 /* ==============================================
@@ -136,15 +174,50 @@ body {
 }
 
 @layer base {
-  * {
-    @apply border-border;
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-coolgray-200, var(--color-border, currentcolor));
+  }
+  :root *,
+  :root ::after,
+  :root ::before {
+    border-color: var(--color-border);
+  }
+  .dark *,
+  .dark ::after,
+  .dark ::before {
+    border-color: var(--color-coolgray-200);
+  }
+
+  h1 {
+    @apply text-3xl font-bold text-black dark:text-white;
+  }
+  h2 {
+    @apply text-xl font-bold text-black dark:text-white;
+  }
+  h3 {
+    @apply text-lg font-bold text-black dark:text-white;
+  }
+  h4 {
+    @apply text-base font-bold text-black dark:text-white;
   }
 }
 
-/* Scrollbar */
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: var(--cool-bg-card-hover); }
-::-webkit-scrollbar-thumb { background: var(--cool-accent); border-radius: 3px; }
+/* Scrollbar — thumb always coollabs-100 per spec */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: var(--cool-bg-card-hover);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-coollabs-100);
+  border-radius: 3px;
+}
 
 /* ==============================================
    COOLIFY INPUT — inset box-shadow system

--- a/ui/src/lib/BucketList.svelte
+++ b/ui/src/lib/BucketList.svelte
@@ -2,7 +2,8 @@
   import { onMount } from 'svelte'
   import * as Table from '$lib/components/ui/table'
   import { Button } from '$lib/components/ui/button'
-  import { Input } from '$lib/components/ui/input'
+  import { Callout } from '$lib/components/ui/callout'
+  import { Badge } from '$lib/components/ui/badge'
   import Database from 'lucide-svelte/icons/database'
   import Plus from 'lucide-svelte/icons/plus'
   import Trash2 from 'lucide-svelte/icons/trash-2'
@@ -109,9 +110,7 @@
 
 <div class="flex flex-col gap-4">
   {#if error}
-    <div class="rounded-sm border border-destructive/50 bg-destructive/10 px-4 py-2 text-sm text-destructive">
-      {error}
-    </div>
+    <Callout type="danger">{error}</Callout>
   {/if}
 
   <div class="flex items-center gap-2">
@@ -142,10 +141,12 @@
   {#if loading && buckets.length === 0}
     <p class="text-sm text-muted-foreground">Loading...</p>
   {:else if buckets.length === 0 && !error}
-    <div class="flex flex-col items-center gap-2 py-12 text-muted-foreground">
-      <Database class="size-10 opacity-30" />
-      <p class="text-sm">No buckets yet</p>
-    </div>
+    <Callout type="info">
+      <span class="inline-flex items-center gap-2">
+        <Database class="size-4 opacity-70" />
+        No buckets yet — create your first bucket to get started.
+      </span>
+    </Callout>
   {:else}
     <Table.Root>
       <Table.Header>
@@ -162,7 +163,7 @@
             <Table.Cell class="font-medium">{bucket.name}</Table.Cell>
             <Table.Cell>
               {#if bucket.versioning}
-                <span class="inline-flex items-center rounded-sm bg-green-500/10 px-1.5 py-0.5 text-[11px] font-medium text-green-500">Enabled</span>
+                <Badge variant="success" label="Enabled" />
               {:else}
                 <span class="text-xs text-muted-foreground">Off</span>
               {/if}

--- a/ui/src/lib/BucketSettings.svelte
+++ b/ui/src/lib/BucketSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { toast } from '$lib/toast'
+  import { Callout } from '$lib/components/ui/callout'
 
   interface Props {
     bucket: string
@@ -66,9 +67,13 @@
 
 <div class="flex flex-col gap-6 max-w-2xl">
   {#if error}
-    <div class="rounded-sm border border-destructive/50 bg-destructive/10 px-4 py-2 text-sm text-destructive">
-      {error}
-    </div>
+    <Callout type="danger">{error}</Callout>
+  {/if}
+
+  {#if versioningEnabled && !loading}
+    <Callout type="warning" title="Disabling versioning is destructive">
+      Turning versioning off permanently deletes all non-current versions. Only the latest version of each object remains.
+    </Callout>
   {/if}
 
   <div class="flex flex-col gap-4">

--- a/ui/src/lib/Login.svelte
+++ b/ui/src/lib/Login.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
+  import { Callout } from "$lib/components/ui/callout";
+  import { Highlighted } from "$lib/components/ui/highlighted";
   import Eye from "lucide-svelte/icons/eye";
   import EyeOff from "lucide-svelte/icons/eye-off";
 
@@ -42,13 +44,13 @@
 <div class="flex min-h-screen w-full items-center justify-center bg-background">
   <div class="w-full max-w-lg px-6">
     <!-- Title -->
-    <h1 class="mb-10 text-center text-4xl font-bold text-foreground">MaxIO</h1>
+    <h1 class="mb-10 text-center text-4xl font-bold">MaxIO</h1>
 
     <form onsubmit={handleSubmit} class="flex flex-col gap-6">
       <!-- Access Key -->
       <div class="flex flex-col gap-1.5">
         <label for="accessKey" class="text-sm text-muted-foreground">
-          Access Key <span class="text-primary">*</span>
+          Access Key <Highlighted>*</Highlighted>
         </label>
         <Input
           id="accessKey"
@@ -62,7 +64,7 @@
       <!-- Secret Key -->
       <div class="flex flex-col gap-1.5">
         <label for="secretKey" class="text-sm text-muted-foreground">
-          Secret Key <span class="text-primary">*</span>
+          Secret Key <Highlighted>*</Highlighted>
         </label>
         <div class="relative">
           <Input
@@ -88,7 +90,7 @@
       </div>
 
       {#if error}
-        <p class="text-sm text-destructive">{error}</p>
+        <Callout type="danger">{error}</Callout>
       {/if}
 
       <!-- Login button — large highlighted style -->

--- a/ui/src/lib/ObjectBrowser.svelte
+++ b/ui/src/lib/ObjectBrowser.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import * as Table from '$lib/components/ui/table'
   import { Button } from '$lib/components/ui/button'
+  import { Callout } from '$lib/components/ui/callout'
   import Folder from 'lucide-svelte/icons/folder'
   import FileIcon from 'lucide-svelte/icons/file'
   import Download from 'lucide-svelte/icons/download'
@@ -302,9 +303,7 @@
 
 <div class="flex flex-col gap-4">
   {#if error}
-    <div class="rounded-sm border border-destructive/50 bg-destructive/10 px-4 py-2 text-sm text-destructive">
-      {error}
-    </div>
+    <Callout type="danger">{error}</Callout>
   {/if}
 
   <div class="flex items-center gap-2">
@@ -345,10 +344,12 @@
   {#if loading && files.length === 0 && prefixes.length === 0}
     <p class="text-sm text-muted-foreground">Loading...</p>
   {:else if files.length === 0 && prefixes.length === 0 && !error}
-    <div class="flex flex-col items-center gap-2 py-12 text-muted-foreground">
-      <Folder class="size-10 opacity-30" />
-      <p class="text-sm">Empty</p>
-    </div>
+    <Callout type="info">
+      <span class="inline-flex items-center gap-2">
+        <Folder class="size-4 opacity-70" />
+        This location is empty — upload a file or create a folder to get started.
+      </span>
+    </Callout>
   {:else}
     <Table.Root>
       <Table.Header>

--- a/ui/src/lib/VersionHistory.svelte
+++ b/ui/src/lib/VersionHistory.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import * as Table from '$lib/components/ui/table'
   import { Button } from '$lib/components/ui/button'
+  import { Callout } from '$lib/components/ui/callout'
   import Download from 'lucide-svelte/icons/download'
   import Trash2 from 'lucide-svelte/icons/trash-2'
   import Tag from 'lucide-svelte/icons/tag'
@@ -103,7 +104,7 @@
   </div>
 
   {#if error}
-    <div class="px-4 py-2 text-sm text-destructive">{error}</div>
+    <div class="p-4"><Callout type="danger">{error}</Callout></div>
   {/if}
 
   {#if loading}

--- a/ui/src/lib/components/ui/badge/badge.svelte
+++ b/ui/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,63 @@
+<script lang="ts" module>
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const badgeVariants = tv({
+		base: "inline-block w-3 h-3 rounded-full leading-none border border-neutral-200 dark:border-black",
+		variants: {
+			variant: {
+				success: "bg-success",
+				warning: "bg-warning",
+				error: "bg-error",
+			},
+		},
+		defaultVariants: {
+			variant: "success",
+		},
+	});
+
+	export type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
+
+	export type BadgeProps = WithElementRef<HTMLAttributes<HTMLSpanElement>> & {
+		variant?: BadgeVariant;
+		label?: string;
+	};
+</script>
+
+<script lang="ts">
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "success",
+		label,
+		...restProps
+	}: BadgeProps = $props();
+
+	const textColor = $derived(
+		variant === "success"
+			? "text-success"
+			: variant === "error"
+				? "text-error"
+				: "text-warning"
+	);
+</script>
+
+{#if label}
+	<span class="inline-flex items-center gap-2">
+		<span
+			bind:this={ref}
+			data-slot="badge"
+			class={cn(badgeVariants({ variant }), className)}
+			{...restProps}
+		></span>
+		<span class="text-xs font-bold {textColor}">{label}</span>
+	</span>
+{:else}
+	<span
+		bind:this={ref}
+		data-slot="badge"
+		class={cn(badgeVariants({ variant }), className)}
+		{...restProps}
+	></span>
+{/if}

--- a/ui/src/lib/components/ui/badge/index.ts
+++ b/ui/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,10 @@
+import Root, { type BadgeProps, type BadgeVariant, badgeVariants } from "./badge.svelte";
+
+export {
+	Root,
+	type BadgeProps as Props,
+	Root as Badge,
+	badgeVariants,
+	type BadgeProps,
+	type BadgeVariant,
+};

--- a/ui/src/lib/components/ui/button/button.svelte
+++ b/ui/src/lib/components/ui/button/button.svelte
@@ -4,21 +4,27 @@
 	import { type VariantProps, tv } from "tailwind-variants";
 
 	export const buttonVariants = tv({
-		base: "inline-flex shrink-0 items-center justify-center gap-2 rounded-sm border-2 text-sm font-medium whitespace-nowrap transition-all outline-none cursor-pointer min-w-fit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		base: "inline-flex shrink-0 items-center justify-center gap-2 rounded-sm border-2 text-sm font-medium whitespace-nowrap transition-all outline-none cursor-pointer min-w-fit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:focus-visible:ring-offset-base disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		variants: {
 			variant: {
-				default: "bg-primary text-primary-foreground border-primary hover:bg-primary-hover",
+				default:
+					"bg-white text-black border-neutral-200 hover:bg-neutral-100 dark:bg-coolgray-100 dark:text-white dark:border-coolgray-300 dark:hover:bg-coolgray-200",
+				highlighted:
+					"text-coollabs-200 bg-coollabs-50 border-coollabs hover:bg-coollabs hover:text-white dark:text-white dark:bg-coollabs/20 dark:border-coollabs-100 dark:hover:bg-coollabs-100 dark:hover:text-white",
 				destructive:
-					"bg-destructive/10 text-destructive border-destructive/50 hover:bg-destructive hover:text-white hover:border-destructive",
+					"text-red-800 bg-red-50 border-red-300 hover:bg-red-300 hover:text-white dark:text-red-300 dark:bg-red-900/30 dark:border-red-800 dark:hover:bg-red-800 dark:hover:text-white",
 				outline:
-					"bg-transparent text-foreground border-border hover:bg-accent hover:text-accent-foreground",
-				secondary: "bg-secondary text-secondary-foreground border-secondary hover:bg-secondary/80",
-				ghost: "border-transparent hover:bg-accent hover:text-accent-foreground",
-				link: "border-transparent text-primary underline-offset-4 hover:underline",
-				brand: "bg-brand text-brand-foreground border border-brand-highlight hover:bg-brand-hover hover:text-brand-foreground",
+					"bg-transparent text-black border-neutral-200 hover:bg-neutral-100 dark:text-white dark:border-coolgray-300 dark:hover:bg-coolgray-200",
+				secondary:
+					"bg-neutral-100 text-black border-neutral-200 hover:bg-neutral-200 dark:bg-coolgray-200 dark:text-white dark:border-coolgray-300 dark:hover:bg-coolgray-300",
+				ghost:
+					"border-transparent text-black hover:bg-neutral-100 dark:text-white dark:hover:bg-coolgray-200",
+				link: "border-transparent text-coollabs dark:text-warning underline-offset-4 hover:underline",
+				brand:
+					"bg-brand text-brand-foreground border-brand-highlight hover:bg-brand-hover hover:text-brand-foreground",
 			},
 			size: {
-				default: "h-8 px-3 py-1.5 has-[>svg]:px-2",
+				default: "h-8 px-2 py-1 has-[>svg]:px-2",
 				sm: "h-7 gap-1.5 px-2.5 has-[>svg]:px-2",
 				lg: "h-10 px-6 has-[>svg]:px-4",
 				icon: "size-8",

--- a/ui/src/lib/components/ui/callout/callout.svelte
+++ b/ui/src/lib/components/ui/callout/callout.svelte
@@ -1,0 +1,61 @@
+<script lang="ts" module>
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const calloutVariants = tv({
+		base: "relative flex gap-3 p-4 rounded-lg border",
+		variants: {
+			type: {
+				warning:
+					"bg-warning-50 border-warning-300 dark:bg-warning-900/30 dark:border-warning-800 [&_.callout-title]:text-warning-800 [&_.callout-body]:text-warning-700 dark:[&_.callout-title]:text-warning-300 dark:[&_.callout-body]:text-warning-200 [&_.callout-icon]:text-warning-700 dark:[&_.callout-icon]:text-warning-300",
+				danger:
+					"bg-red-50 border-red-300 dark:bg-red-900/30 dark:border-red-800 [&_.callout-title]:text-red-800 [&_.callout-body]:text-red-700 dark:[&_.callout-title]:text-red-300 dark:[&_.callout-body]:text-red-200 [&_.callout-icon]:text-red-700 dark:[&_.callout-icon]:text-red-300",
+				info: "bg-blue-50 border-blue-300 dark:bg-blue-900/30 dark:border-blue-800 [&_.callout-title]:text-blue-800 [&_.callout-body]:text-blue-700 dark:[&_.callout-title]:text-blue-300 dark:[&_.callout-body]:text-blue-200 [&_.callout-icon]:text-blue-700 dark:[&_.callout-icon]:text-blue-300",
+				success:
+					"bg-green-50 border-green-300 dark:bg-green-900/30 dark:border-green-800 [&_.callout-title]:text-green-800 [&_.callout-body]:text-green-700 dark:[&_.callout-title]:text-green-300 dark:[&_.callout-body]:text-green-200 [&_.callout-icon]:text-green-700 dark:[&_.callout-icon]:text-green-300",
+			},
+		},
+		defaultVariants: {
+			type: "info",
+		},
+	});
+
+	export type CalloutType = VariantProps<typeof calloutVariants>["type"];
+
+	export type CalloutProps = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		type?: CalloutType;
+		title?: string;
+		icon?: import("svelte").Snippet;
+	};
+</script>
+
+<script lang="ts">
+	let {
+		ref = $bindable(null),
+		class: className,
+		type = "info",
+		title,
+		icon,
+		children,
+		...restProps
+	}: CalloutProps = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="callout"
+	role="alert"
+	class={cn(calloutVariants({ type }), className)}
+	{...restProps}
+>
+	{#if icon}
+		<div class="callout-icon shrink-0">{@render icon()}</div>
+	{/if}
+	<div class="flex-1 text-sm">
+		{#if title}
+			<div class="callout-title font-bold mb-1">{title}</div>
+		{/if}
+		<div class="callout-body">{@render children?.()}</div>
+	</div>
+</div>

--- a/ui/src/lib/components/ui/callout/index.ts
+++ b/ui/src/lib/components/ui/callout/index.ts
@@ -1,0 +1,10 @@
+import Root, { type CalloutProps, type CalloutType, calloutVariants } from "./callout.svelte";
+
+export {
+	Root,
+	type CalloutProps as Props,
+	Root as Callout,
+	calloutVariants,
+	type CalloutProps,
+	type CalloutType,
+};

--- a/ui/src/lib/components/ui/card/card-title.svelte
+++ b/ui/src/lib/components/ui/card/card-title.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-title"
-	class={cn("leading-none font-semibold", className)}
+	class={cn("leading-none font-semibold text-black dark:text-white", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/ui/src/lib/components/ui/card/card.svelte
+++ b/ui/src/lib/components/ui/card/card.svelte
@@ -1,22 +1,44 @@
-<script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
+<script lang="ts" module>
 	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { type VariantProps, tv } from "tailwind-variants";
 
+	export const cardVariants = tv({
+		base: "group bg-card text-card-foreground flex flex-col gap-6 rounded-sm border border-border py-6 shadow-sm min-h-16 transition-colors",
+		variants: {
+			variant: {
+				default: "",
+				box: "cursor-pointer hover:bg-neutral-100 dark:hover:bg-coollabs-100 dark:hover:text-white hover:text-black dark:group-hover:[&_[data-slot=card-title]]:text-white dark:group-hover:[&_[data-slot=card-description]]:text-white group-hover:[&_[data-slot=card-description]]:text-black",
+				coolbox:
+					"rounded cursor-pointer border-neutral-200 dark:border-coolgray-400 hover:ring-2 hover:ring-coollabs dark:hover:ring-warning",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type CardVariant = VariantProps<typeof cardVariants>["variant"];
+
+	export type CardProps = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		variant?: CardVariant;
+	};
+</script>
+
+<script lang="ts">
 	let {
 		ref = $bindable(null),
 		class: className,
+		variant = "default",
 		children,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+	}: CardProps = $props();
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="card"
-	class={cn(
-		"bg-card text-card-foreground flex flex-col gap-6 rounded-sm border border-border py-6 shadow-none min-h-16 transition-colors",
-		className
-	)}
+	class={cn(cardVariants({ variant }), className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/ui/src/lib/components/ui/card/index.ts
+++ b/ui/src/lib/components/ui/card/index.ts
@@ -1,4 +1,4 @@
-import Root from "./card.svelte";
+import Root, { type CardProps, type CardVariant, cardVariants } from "./card.svelte";
 import Content from "./card-content.svelte";
 import Description from "./card-description.svelte";
 import Footer from "./card-footer.svelte";
@@ -14,7 +14,6 @@ export {
 	Header,
 	Title,
 	Action,
-	//
 	Root as Card,
 	Content as CardContent,
 	Description as CardDescription,
@@ -22,4 +21,7 @@ export {
 	Header as CardHeader,
 	Title as CardTitle,
 	Action as CardAction,
+	cardVariants,
+	type CardProps,
+	type CardVariant,
 };

--- a/ui/src/lib/components/ui/helper/helper.svelte
+++ b/ui/src/lib/components/ui/helper/helper.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import HelpCircle from "lucide-svelte/icons/circle-help";
+
+	type Props = {
+		text: string;
+		class?: string;
+	};
+
+	let { text, class: className }: Props = $props();
+</script>
+
+<span class={cn("group relative inline-flex items-center", className)}>
+	<HelpCircle class="size-4 text-coollabs dark:text-warning cursor-pointer" />
+	<span
+		role="tooltip"
+		class="hidden group-hover:block absolute left-5 top-0 z-40 max-w-sm text-xs bg-neutral-200 dark:bg-coolgray-400 text-neutral-700 dark:text-neutral-300 rounded-sm p-2 shadow-md"
+	>
+		{text}
+	</span>
+</span>

--- a/ui/src/lib/components/ui/helper/index.ts
+++ b/ui/src/lib/components/ui/helper/index.ts
@@ -1,0 +1,3 @@
+import Root from "./helper.svelte";
+
+export { Root, Root as Helper };

--- a/ui/src/lib/components/ui/highlighted/highlighted.svelte
+++ b/ui/src/lib/components/ui/highlighted/highlighted.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="highlighted"
+	class={cn("inline-block font-bold text-coollabs dark:text-warning", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/ui/src/lib/components/ui/highlighted/index.ts
+++ b/ui/src/lib/components/ui/highlighted/index.ts
@@ -1,0 +1,3 @@
+import Root from "./highlighted.svelte";
+
+export { Root, Root as Highlighted };

--- a/ui/src/lib/components/ui/kbd/index.ts
+++ b/ui/src/lib/components/ui/kbd/index.ts
@@ -1,0 +1,3 @@
+import Root from "./kbd.svelte";
+
+export { Root, Root as Kbd };

--- a/ui/src/lib/components/ui/kbd/kbd.svelte
+++ b/ui/src/lib/components/ui/kbd/kbd.svelte
@@ -7,17 +7,17 @@
 		class: className,
 		children,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
 </script>
 
-<tr
+<kbd
 	bind:this={ref}
-	data-slot="table-row"
+	data-slot="kbd"
 	class={cn(
-		"border-b border-neutral-200 dark:border-coolgray-200 transition-colors hover:bg-neutral-100 dark:hover:bg-coolgray-300 data-[state=selected]:bg-neutral-100 dark:data-[state=selected]:bg-coolgray-300",
+		"inline-block px-2 text-xs rounded-sm border border-dashed border-neutral-700 dark:text-warning",
 		className
 	)}
 	{...restProps}
 >
 	{@render children?.()}
-</tr>
+</kbd>

--- a/ui/src/lib/components/ui/sonner/sonner.svelte
+++ b/ui/src/lib/components/ui/sonner/sonner.svelte
@@ -10,19 +10,20 @@
 <Toaster
   {theme}
   position="bottom-right"
-  richColors
   closeButton
   duration={4000}
   toastOptions={{
     classes: {
-      toast: 'group !rounded-sm !shadow-lg !font-sans !text-sm !bg-[var(--cool-bg-card)] !text-[var(--cool-fg)] !border !border-[var(--cool-border)]',
-      title: '!font-medium',
-      description: '!text-[var(--cool-fg-muted)]',
-      success: '!border-l-4 !border-l-[var(--cool-success)]',
-      error: '!border-l-4 !border-l-[var(--cool-error)]',
-      warning: '!border-l-4 !border-l-[#f59e0b]',
-      info: '!border-l-4 !border-l-[var(--cool-accent)]',
-      closeButton: '!bg-[var(--cool-bg-card)] !border-[var(--cool-border)] !text-[var(--cool-fg-muted)] hover:!text-[var(--cool-fg)]',
+      toast:
+        'group !rounded-sm !font-sans !text-sm !bg-white dark:!bg-coolgray-100 !text-black dark:!text-white !border dark:!border-coolgray-200 !border-neutral-200 !shadow-[0_5px_15px_-3px_rgb(0_0_0_/_0.08)]',
+      title: '!font-semibold',
+      description: '!text-neutral-500 dark:!text-neutral-400',
+      success: '!border-l-4 !border-l-green-500 [&_[data-icon]]:!text-green-500',
+      error: '!border-l-4 !border-l-red-500 [&_[data-icon]]:!text-red-500',
+      warning: '!border-l-4 !border-l-orange-400 [&_[data-icon]]:!text-orange-400',
+      info: '!border-l-4 !border-l-blue-500 [&_[data-icon]]:!text-blue-500',
+      closeButton:
+        '!bg-white dark:!bg-coolgray-100 !border-neutral-200 dark:!border-coolgray-200 !text-neutral-500 hover:!text-black dark:hover:!text-white',
     },
   }}
 />

--- a/ui/src/lib/components/ui/table/table-head.svelte
+++ b/ui/src/lib/components/ui/table/table-head.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		"text-foreground h-10 bg-clip-padding px-2 text-start align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pe-0",
+		"text-neutral-500 dark:text-neutral-400 h-10 bg-clip-padding px-2 text-start align-middle text-xs font-bold uppercase tracking-wide whitespace-nowrap [&:has([role=checkbox])]:pe-0",
 		className
 	)}
 	{...restProps}

--- a/ui/src/lib/components/ui/table/table.svelte
+++ b/ui/src/lib/components/ui/table/table.svelte
@@ -14,7 +14,10 @@
 	<table
 		bind:this={ref}
 		data-slot="table"
-		class={cn("w-full caption-bottom text-sm", className)}
+		class={cn(
+			"min-w-full caption-bottom text-sm divide-y divide-neutral-300 dark:divide-coolgray-200",
+			className
+		)}
 		{...restProps}
 	>
 		{@render children?.()}

--- a/ui/src/lib/components/ui/tag/index.ts
+++ b/ui/src/lib/components/ui/tag/index.ts
@@ -1,0 +1,3 @@
+import Root from "./tag.svelte";
+
+export { Root, Root as Tag };

--- a/ui/src/lib/components/ui/tag/tag.svelte
+++ b/ui/src/lib/components/ui/tag/tag.svelte
@@ -7,17 +7,17 @@
 		class: className,
 		children,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
 </script>
 
-<tr
+<span
 	bind:this={ref}
-	data-slot="table-row"
+	data-slot="tag"
 	class={cn(
-		"border-b border-neutral-200 dark:border-coolgray-200 transition-colors hover:bg-neutral-100 dark:hover:bg-coolgray-300 data-[state=selected]:bg-neutral-100 dark:data-[state=selected]:bg-coolgray-300",
+		"inline-flex items-center px-2 py-1 text-xs font-bold rounded-sm text-neutral-500 bg-neutral-100 hover:bg-neutral-200 dark:bg-coolgray-100 dark:hover:bg-coolgray-300 cursor-pointer",
 		className
 	)}
 	{...restProps}
 >
 	{@render children?.()}
-</tr>
+</span>


### PR DESCRIPTION
## Summary

- **Font**: Replace Google Fonts Inter with self-hosted Geist Sans + Geist Mono via `@fontsource` packages; remove external `<link>` tags from `index.html`
- **Button variants**: Rework all button styles to explicit light/dark Tailwind classes; add `highlighted` variant; update focus ring to use `coollabs`/`warning` tokens
- **Card component**: Add `variant` prop (`default`, `box`, `coolbox`) via `tailwind-variants`; expose `cardVariants` and types from index
- **Callout component** (new): Semantic alert box with `type` (`info`, `warning`, `danger`, `success`) and optional `title`; replaces raw error `<div>` blocks across `BucketList`, `BucketSettings`, `ObjectBrowser`, `Login`, `VersionHistory`
- **Badge component** (new): Dot indicator with `variant` (`success`, `warning`, `error`) and optional `label`; replaces inline versioning badge in `BucketList`
- **Highlighted component** (new): Inline accent `<span>` using brand purple/warning yellow per theme
- **Helper component** (new): Hover tooltip trigger using `HelpCircle` icon
- **Kbd component** (new): Keyboard shortcut `<kbd>` element with dashed border styling
- **Tag component** (new): Clickable label chip for metadata display
- **CSS tokens**: Add `coollabs`, `warning`, `coolgray` color scales; add `--color-error`; fix `@custom-variant dark` for class-based dark mode; expand heading styles in `@layer base`
- **Table**: Restyle header (muted, uppercase, tracking), rows (explicit border/hover colors), and table dividers using design tokens
- **Toast (Sonner)**: Restyle to explicit light/dark classes; remove `richColors`; update close button and icon selectors
- **CLAUDE.md**: Update font and button variant docs to match new implementation
