### PR TITLE
Add file preview (+content-type detection on upload)

### DIFF
--- a/src/api/console.rs
+++ b/src/api/console.rs
@@ -484,6 +484,7 @@ pub async fn list_objects(
                 "size": obj.size,
                 "lastModified": obj.last_modified,
                 "etag": obj.etag,
+                "contentType": obj.content_type,
             }));
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,7 +70,7 @@ async fn security_headers_middleware(
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
     headers.entry(header::CONTENT_SECURITY_POLICY).or_insert_with(|| {
-        HeaderValue::from_static("default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'self'")
+        HeaderValue::from_static("default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; frame-src 'self' blob:; form-action 'self'")
     });
     headers
         .entry(header::X_CONTENT_TYPE_OPTIONS)

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -11,6 +11,7 @@
         "bits-ui": "^2.15.7",
         "clsx": "^2.1.1",
         "lucide-svelte": "^0.574.0",
+        "mrmime": "^2.0.1",
         "svelte-sonner": "^1.0.7",
         "tailwind-merge": "^3.4.1",
         "tailwind-variants": "^3.2.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,7 @@
     "bits-ui": "^2.15.7",
     "clsx": "^2.1.1",
     "lucide-svelte": "^0.574.0",
+    "mrmime": "^2.0.1",
     "svelte-sonner": "^1.0.7",
     "tailwind-merge": "^3.4.1",
     "tailwind-variants": "^3.2.2"

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -173,6 +173,13 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* While a file preview is open, keep text selection inside the preview body
+   instead of bleeding into the page behind the modal. The preview content
+   re-enables selection via `select-text`. */
+body.preview-open {
+  user-select: none;
+}
+
 @layer base {
   *,
   ::after,

--- a/ui/src/lib/FilePreview.svelte
+++ b/ui/src/lib/FilePreview.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { Dialog } from '$lib/components/ui/dialog'
+  import Download from 'lucide-svelte/icons/download'
+  import { downloadUrl as objectDownloadUrl } from '$lib/api/objects'
+  import { displayName } from '$lib/utils'
+  import { previewKind, BINARY_PREVIEW_CAP, TEXT_PREVIEW_CAP, type PreviewKind } from '$lib/preview'
+
+  interface Props {
+    bucket: string
+    objectKey: string
+    contentType: string
+    size: number
+    onClose: () => void
+  }
+  let { bucket, objectKey, contentType, size, onClose }: Props = $props()
+
+  const kind: PreviewKind = $derived(previewKind(contentType))
+  const name = $derived(displayName(objectKey))
+  const downloadUrl = $derived(objectDownloadUrl(bucket, objectKey))
+  const tooLarge = $derived(size > BINARY_PREVIEW_CAP)
+
+  let loading = $state(true)
+  let error = $state<string | null>(null)
+  let blobUrl = $state<string | null>(null)
+  let textContent = $state('')
+  let truncated = $state(false)
+
+  async function load() {
+    if (kind === 'unsupported' || tooLarge) {
+      loading = false
+      return
+    }
+    try {
+      const res = await fetch(downloadUrl, { credentials: 'same-origin' })
+      if (!res.ok) throw new Error(`Request failed (${res.status})`)
+      if (kind === 'text') {
+        let text = await res.text()
+        if (text.length > TEXT_PREVIEW_CAP) {
+          text = text.slice(0, TEXT_PREVIEW_CAP)
+          truncated = true
+        }
+        textContent = text
+      } else {
+        blobUrl = URL.createObjectURL(await res.blob())
+      }
+    } catch (err) {
+      console.error('FilePreview load failed:', err)
+      error = err instanceof Error ? err.message : 'Failed to load preview'
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(() => {
+    load()
+    document.body.classList.add('preview-open')
+    return () => {
+      document.body.classList.remove('preview-open')
+      if (blobUrl) URL.revokeObjectURL(blobUrl)
+    }
+  })
+</script>
+
+<Dialog open size="lg" title={name} description={contentType || 'unknown type'} {onClose}>
+  {#if loading}
+    <p class="text-sm text-neutral-600 dark:text-neutral-400">Loading preview…</p>
+  {:else if error}
+    <p class="text-sm text-red-600 dark:text-red-400">{error}</p>
+  {:else if kind === 'unsupported'}
+    <p class="text-sm text-neutral-600 dark:text-neutral-400">No preview available for this file type.</p>
+  {:else if tooLarge}
+    <p class="text-sm text-neutral-600 dark:text-neutral-400">File is too large to preview. Download it to view.</p>
+  {:else if kind === 'image' && blobUrl}
+    <img src={blobUrl} alt={name} class="mx-auto max-h-[70vh] max-w-full object-contain" />
+  {:else if kind === 'pdf' && blobUrl}
+    <iframe src={blobUrl} title={name} class="h-[70vh] w-full border-0"></iframe>
+  {:else if kind === 'text'}
+    {#if truncated}
+      <p class="mb-2 text-xs text-amber-600 dark:text-amber-400">Preview truncated to the first {Math.round(TEXT_PREVIEW_CAP / 1024)} KB.</p>
+    {/if}
+    <pre class="select-text overflow-auto whitespace-pre-wrap break-words rounded-sm bg-neutral-50 p-3 font-mono text-xs text-neutral-800 dark:bg-coolgray-200 dark:text-neutral-200">{textContent}</pre>
+  {/if}
+  {#snippet footer()}
+    <Button href={downloadUrl} variant="default">
+      <Download class="size-4 mr-1" /> Download
+    </Button>
+  {/snippet}
+</Dialog>

--- a/ui/src/lib/ObjectBrowser.svelte
+++ b/ui/src/lib/ObjectBrowser.svelte
@@ -16,13 +16,17 @@
   import Check from 'lucide-svelte/icons/check'
   import FolderPlus from 'lucide-svelte/icons/folder-plus'
   import History from 'lucide-svelte/icons/history'
+  import Eye from 'lucide-svelte/icons/eye'
   import VersionHistory from './VersionHistory.svelte'
+  import FilePreview from './FilePreview.svelte'
+  import { isPreviewable } from '$lib/preview'
   import { toast } from '$lib/toast'
   import { objectKeys, settingsKeys } from '$lib/api/keys'
-  import { createFolder as createFolderApi, deleteObject as deleteObjectApi, listObjects, presignObject, uploadObject } from '$lib/api/objects'
+  import { createFolder as createFolderApi, deleteObject as deleteObjectApi, downloadUrl, listObjects, presignObject, uploadObject, type S3File } from '$lib/api/objects'
   import { getVersioning } from '$lib/api/settings'
-  import { ApiError, encodeObjectKey } from '$lib/api/http'
+  import { ApiError } from '$lib/api/http'
   import { queryClient } from '$lib/query/client'
+  import { displayName } from '$lib/utils'
 
   interface Props {
     bucket: string
@@ -39,6 +43,7 @@
   let newFolderName = $state('')
   let shareMenuPos = $state({ top: 0, left: 0 })
   let versionKey = $state<string | null>(null)
+  let previewFile = $state<S3File | null>(null)
   let pendingDelete = $state<{ key: string; kind: 'object' | 'folder' } | null>(null)
   let createFolderInput = $state<HTMLInputElement | null>(null)
 
@@ -123,12 +128,6 @@
     notifyPrefix()
   }
 
-  function displayName(fullPath: string): string {
-    const trimmed = fullPath.endsWith('/') ? fullPath.slice(0, -1) : fullPath
-    const lastSlash = trimmed.lastIndexOf('/')
-    return lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed
-  }
-
   function formatSize(bytes: number): string {
     if (bytes < 1024) return `${bytes} B`
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
@@ -156,10 +155,6 @@
     }
     return crumbs
   })
-
-  function downloadUrl(key: string): string {
-    return `/api/buckets/${encodeURIComponent(bucket)}/download/${encodeObjectKey(key)}`
-  }
 
   async function handleUpload() {
     const inputFiles = fileInput?.files
@@ -279,6 +274,7 @@
       <Table.Header>
         <Table.Row>
           <Table.Head>Name</Table.Head>
+          <Table.Head class="w-48">Type</Table.Head>
           <Table.Head class="w-28 text-right">Size</Table.Head>
           <Table.Head class="w-48">Modified</Table.Head>
           <Table.Head class="w-24"></Table.Head>
@@ -293,9 +289,10 @@
                 <span class="font-medium">{displayName(p)}/</span>
               </span>
             </Table.Cell>
+            <Table.Cell class="text-muted-foreground">&mdash;</Table.Cell>
             <Table.Cell class="text-right text-muted-foreground">&mdash;</Table.Cell>
             <Table.Cell class="text-muted-foreground">&mdash;</Table.Cell>
-            <Table.Cell>
+            <Table.Cell class="w-24 text-right">
               {#if emptyPrefixes.has(p)}
                 <button
                   class="text-muted-foreground hover:text-destructive transition-colors"
@@ -316,10 +313,11 @@
                 <span class="font-medium">{displayName(file.key)}</span>
               </span>
             </Table.Cell>
+            <Table.Cell class="truncate text-muted-foreground">{file.contentType || '—'}</Table.Cell>
             <Table.Cell class="text-right text-muted-foreground">{formatSize(file.size)}</Table.Cell>
             <Table.Cell class="text-muted-foreground">{formatDate(file.lastModified)}</Table.Cell>
             <Table.Cell class="w-24">
-              <span class="flex items-center gap-4">
+              <span class="flex items-center justify-end gap-4">
                 {#if versioningEnabled}
                   <button
                     class="text-muted-foreground hover:text-foreground transition-colors"
@@ -327,6 +325,15 @@
                     title="Version history"
                   >
                     <History class="size-4" />
+                  </button>
+                {/if}
+                {#if isPreviewable(file.contentType)}
+                  <button
+                    class="text-muted-foreground hover:text-foreground transition-colors"
+                    onclick={(e) => { e.stopPropagation(); previewFile = file }}
+                    title="Preview"
+                  >
+                    <Eye class="size-4" />
                   </button>
                 {/if}
                 <button
@@ -340,7 +347,7 @@
                     <Share2 class="size-4" />
                   {/if}
                 </button>
-                <a href={downloadUrl(file.key)} class="text-muted-foreground hover:text-foreground" onclick={(e) => e.stopPropagation()} title="Download">
+                <a href={downloadUrl(bucket, file.key)} class="text-muted-foreground hover:text-foreground" onclick={(e) => e.stopPropagation()} title="Download">
                   <Download class="size-4" />
                 </a>
                 <button
@@ -355,7 +362,7 @@
           </Table.Row>
           {#if versionKey === file.key}
             <Table.Row>
-              <Table.Cell colspan={4} class="p-0">
+              <Table.Cell colspan={5} class="p-0">
                 <div class="p-2">
                   <VersionHistory
                     {bucket}
@@ -418,6 +425,16 @@
       </button>
     {/each}
   </div>
+{/if}
+
+{#if previewFile}
+  <FilePreview
+    {bucket}
+    objectKey={previewFile.key}
+    contentType={previewFile.contentType}
+    size={previewFile.size}
+    onClose={() => (previewFile = null)}
+  />
 {/if}
 
 {#if pendingDelete}

--- a/ui/src/lib/api/objects.ts
+++ b/ui/src/lib/api/objects.ts
@@ -1,10 +1,12 @@
 import { apiFetch, encodeObjectKey } from './http'
+import { guessContentType } from '$lib/mime'
 
 export interface S3File {
   key: string
   size: number
   lastModified: string
   etag: string
+  contentType: string
 }
 
 export interface ObjectsResponse {
@@ -19,10 +21,12 @@ export async function listObjects(bucket: string, prefix: string): Promise<Objec
 }
 
 export async function uploadObject(bucket: string, key: string, file: File): Promise<{ ok: boolean }> {
+  const contentType = file.type || guessContentType(file.name)
   const res = await fetch(`/api/buckets/${encodeURIComponent(bucket)}/upload/${encodeObjectKey(key)}`, {
     method: 'PUT',
     body: file,
     credentials: 'same-origin',
+    headers: contentType ? { 'Content-Type': contentType } : undefined,
   })
   if (!res.ok) throw new Error(`Upload failed (${res.status})`)
   return { ok: true }
@@ -41,4 +45,8 @@ export async function createFolder(bucket: string, name: string): Promise<{ ok: 
 
 export async function presignObject(bucket: string, key: string, expires: number): Promise<{ url: string }> {
   return apiFetch<{ url: string }>(`/api/buckets/${encodeURIComponent(bucket)}/presign/${encodeObjectKey(key)}?expires=${expires}`)
+}
+
+export function downloadUrl(bucket: string, key: string): string {
+  return `/api/buckets/${encodeURIComponent(bucket)}/download/${encodeObjectKey(key)}`
 }

--- a/ui/src/lib/components/ui/dialog/dialog.svelte
+++ b/ui/src/lib/components/ui/dialog/dialog.svelte
@@ -6,6 +6,7 @@
     title: string
     description?: string
     loading?: boolean
+    size?: 'default' | 'lg'
     onClose?: () => void
     children?: import('svelte').Snippet
     footer?: import('svelte').Snippet
@@ -16,6 +17,7 @@
     title,
     description,
     loading = false,
+    size = 'default',
     onClose,
     children,
     footer,
@@ -46,19 +48,19 @@
     disabled={loading}
     onclick={close}
   ></button>
-  <div class="fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2">
+  <div class="fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] {size === 'lg' ? 'max-w-4xl' : 'max-w-lg'} -translate-x-1/2 -translate-y-1/2">
     <div
       role="dialog"
       aria-modal="true"
       aria-labelledby="dialog-title"
       tabindex="-1"
-      class="rounded-sm border border-neutral-200 bg-white p-4 text-black shadow-sm dark:border-coolgray-300 dark:bg-coolgray-100 dark:text-white"
+      class="max-h-[calc(100vh-2rem)] overflow-y-auto rounded-sm border border-neutral-200 bg-white p-4 text-black shadow-sm dark:border-coolgray-300 dark:bg-coolgray-100 dark:text-white"
     >
       <div class="flex items-start justify-between gap-4 border-b border-neutral-200 pb-3 dark:border-coolgray-200">
-        <div class="flex flex-col gap-1">
-          <h2 id="dialog-title" class="text-base font-bold text-black dark:text-white">{title}</h2>
+        <div class="flex min-w-0 flex-col gap-1">
+          <h2 id="dialog-title" class="truncate text-base font-bold text-black dark:text-white">{title}</h2>
           {#if description}
-            <p class="text-sm text-neutral-600 dark:text-neutral-400">{description}</p>
+            <p class="truncate text-sm text-neutral-600 dark:text-neutral-400">{description}</p>
           {/if}
         </div>
         <Button

--- a/ui/src/lib/mime.ts
+++ b/ui/src/lib/mime.ts
@@ -1,0 +1,45 @@
+import { lookup } from 'mrmime'
+
+const OVERRIDES: Record<string, string> = {
+  // extensionless config files, matched on the full lowercased filename
+  dockerfile: 'text/plain',
+  makefile: 'text/plain',
+  '.gitignore': 'text/plain',
+  '.dockerignore': 'text/plain',
+  '.env': 'text/plain',
+  // mrmime mistypes these (e.g. .ts -> video/mp2t); force text
+  ts: 'text/plain',
+  tsx: 'text/plain',
+  jsx: 'text/plain',
+  rs: 'text/x-rust',
+  // source / scripts / config mrmime has no entry for
+  sh: 'application/x-sh',
+  bash: 'application/x-sh',
+  zsh: 'application/x-sh',
+  py: 'text/x-python',
+  rb: 'text/x-ruby',
+  go: 'text/x-go',
+  c: 'text/x-c',
+  h: 'text/x-c',
+  cpp: 'text/x-c++',
+  cc: 'text/x-c++',
+  java: 'text/x-java',
+  php: 'text/x-php',
+  scss: 'text/plain',
+  less: 'text/plain',
+  sql: 'text/plain',
+  ini: 'text/plain',
+  conf: 'text/plain',
+  cfg: 'text/plain',
+  env: 'text/plain',
+  properties: 'text/plain',
+  jsonc: 'application/json',
+}
+
+export function guessContentType(filename: string): string | undefined {
+  const name = filename.toLowerCase()
+  if (name in OVERRIDES) return OVERRIDES[name]
+  const dot = name.lastIndexOf('.')
+  const ext = dot >= 0 ? name.slice(dot + 1) : name
+  return OVERRIDES[ext] ?? lookup(name)
+}

--- a/ui/src/lib/preview.ts
+++ b/ui/src/lib/preview.ts
@@ -1,0 +1,46 @@
+export type PreviewKind = 'image' | 'pdf' | 'text' | 'unsupported'
+
+export const TEXT_PREVIEW_CAP = 1024 * 1024 // 1 MiB
+export const BINARY_PREVIEW_CAP = 10 * 1024 * 1024 // 10 MiB
+
+// application/* subtypes that are really text (some clients label scripts and
+// config files with these rather than a text/* type).
+const TEXT_APP_TYPES = new Set([
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/x-javascript',
+  'application/x-sh',
+  'application/x-shellscript',
+  'application/yaml',
+  'application/x-yaml',
+  'application/toml',
+  'application/x-toml',
+])
+
+function normalize(contentType: string): string {
+  return contentType.split(';')[0].trim().toLowerCase()
+}
+
+export function previewKind(contentType: string): PreviewKind {
+  const ct = normalize(contentType)
+  if (!ct) return 'unsupported'
+
+  // SVG renders safely via <img> (no script execution in that context).
+  if (ct.startsWith('image/')) return 'image'
+  if (ct === 'application/pdf') return 'pdf'
+
+  // text/* is previewable EXCEPT text/html, which we never render inline to
+  // avoid stored-XSS in the console's same-origin session.
+  if (ct === 'text/html') return 'unsupported'
+  if (ct.startsWith('text/')) return 'text'
+
+  if (TEXT_APP_TYPES.has(ct)) return 'text'
+  if (ct.endsWith('+json') || ct.endsWith('+xml')) return 'text'
+
+  return 'unsupported'
+}
+
+export function isPreviewable(contentType: string): boolean {
+  return previewKind(contentType) !== 'unsupported'
+}

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -5,4 +5,10 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
+export function displayName(fullPath: string): string {
+	const trimmed = fullPath.endsWith('/') ? fullPath.slice(0, -1) : fullPath
+	const lastSlash = trimmed.lastIndexOf('/')
+	return lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed
+}
+
 export type { WithElementRef } from "bits-ui";


### PR DESCRIPTION
Adds in-browser file preview to the web console. Users can now preview files directly from the object browser without downloading, via an eye icon that appears on previewable files.

Preview is driven entirely by `Content-Type`. The frontend guesses the type client-side at upload time (using `mrmime` + a small override layer for source-code and extensionless files like `Dockerfile`).

Preview support:
  - Images: rendered via `<img>`
  - PDF: rendered via `<iframe>`
  - Text & code: rendered in `<pre>` 

<img width="888" height="167" alt="image" src="https://github.com/user-attachments/assets/1f549df2-4a09-4c6c-96d5-4348cb9bd07c" />
<img width="991" height="426" alt="image" src="https://github.com/user-attachments/assets/060a08d6-6003-4212-9059-f55952c737cc" />
<img width="991" height="877" alt="image" src="https://github.com/user-attachments/assets/2ee27311-7296-4679-bee0-cbaa260af025" />


**This feature has been partially implemented by Claude Opus 4.8. All modification done by the AI have been reviewed by me.**
