### PR TITLE
feat(config): add MAXIO_PUBLIC_BUCKETS for anonymous public-read buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Open `http://localhost:9000/ui/` in your browser. Default credentials: `maxioadm
 | `MAXIO_PARITY_SHARDS` | `--parity-shards` | `0` | Number of parity shards per object (requires `--erasure-coding`, 0 = no parity) |
 | `MAXIO_MASTER_KEY` | `--master-key` | _(auto-generated)_ | Base64-encoded 32-byte SSE-S3 master key. If unset, a key is generated and stored under `<data-dir>/.maxio-keys.json`. Provide explicitly to control key rotation |
 | `MAXIO_DEFAULT_BUCKETS` | `--default-buckets` | _(none)_ | Comma-separated list of bucket names to create during startup (aliases: `MINIO_DEFAULT_BUCKETS`) |
+| `MAXIO_PUBLIC_BUCKETS` | `--public-buckets` | _(none)_ | Comma-separated bucket names to expose as anonymous public-read. Each is created on startup if missing, then flagged public-read (not public-list) — the equivalent of MinIO's `mc anonymous set download` (aliases: `MINIO_PUBLIC_BUCKETS`) |
 | `MAXIO_MAX_CONSOLE_BODY_BYTES` | `--max-console-body-bytes` | `1048576` | Max request body size for console JSON/form API routes; object uploads are streaming and not covered by this limit |
 | `MAXIO_HEALTHCHECK_URL` | `healthcheck --url` | `http://127.0.0.1:9000/healthz` | Healthcheck endpoint URL; default port follows `MAXIO_PORT` when set |
 | `MAXIO_HEALTHCHECK_TIMEOUT_MS` | `healthcheck --timeout-ms` | `2000` | Healthcheck connect/read timeout in milliseconds |

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -145,8 +145,10 @@ fn redact_header_value(name: &str) -> &'static str {
 ///   - Path must be `/{bucket}` (list) or `/{bucket}/{key}` (object).
 ///   - For bucket-level path: `public_list` must be true.
 ///   - For object path: `public_read` must be true.
-///   - Query must not contain mutating sub-resources (`delete`, `uploads`, `tagging`,
-///     `versioning`, `cors`, `encryption`, `policy`, `acl`).
+///   - Query must not contain mutating or non-object-read sub-resources
+///     (`delete`, `uploads`, `uploadId`, `partNumber`, `tagging`, `versioning`,
+///     `cors`, `encryption`, `policy`, `acl`). `uploadId`/`partNumber` route to
+///     multipart `list_parts`, which is a distinct surface from object read.
 async fn is_public_bypass_allowed(state: &AppState, method: &str, path: &str, query: &str) -> bool {
     match method {
         "GET" | "HEAD" | "OPTIONS" => {}
@@ -157,6 +159,8 @@ async fn is_public_bypass_allowed(state: &AppState, method: &str, path: &str, qu
     for forbidden in [
         "delete",
         "uploads",
+        "uploadId",
+        "partNumber",
         "tagging",
         "versioning",
         "cors",

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,10 @@ fn default_default_buckets() -> Option<String> {
     first_env_value(&["MINIO_DEFAULT_BUCKETS"])
 }
 
+fn default_public_buckets() -> Option<String> {
+    first_env_value(&["MINIO_PUBLIC_BUCKETS"])
+}
+
 #[derive(Args, Debug, Clone)]
 pub struct Config {
     /// Port to listen on
@@ -80,6 +84,13 @@ pub struct Config {
     /// (MAXIO_DEFAULT_BUCKETS, MINIO_DEFAULT_BUCKETS)
     #[arg(long, env = "MAXIO_DEFAULT_BUCKETS", default_value_t = default_default_buckets().unwrap_or_default())]
     pub default_buckets: String,
+
+    /// Comma-separated list of bucket names to expose as anonymous public-read.
+    /// Each is created on first boot if missing, then flagged public-read (but
+    /// not public-list) — the equivalent of MinIO's `mc anonymous set download`.
+    /// (MAXIO_PUBLIC_BUCKETS, MINIO_PUBLIC_BUCKETS)
+    #[arg(long, env = "MAXIO_PUBLIC_BUCKETS", default_value_t = default_public_buckets().unwrap_or_default())]
+    pub public_buckets: String,
 
     /// Max request body size for console JSON/form API routes, in bytes. Object uploads are streaming and not covered by this limit.
     #[arg(long, env = "MAXIO_MAX_CONSOLE_BODY_BYTES", default_value = "1048576")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     storage::provision_default_buckets(&storage, &config.default_buckets, &config.region).await;
+    storage::provision_public_buckets(&storage, &config.public_buckets, &config.region).await;
 
     let state = server::AppState {
         storage: Arc::new(storage),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -359,6 +359,71 @@ pub async fn provision_default_buckets(
     }
 }
 
+/// For each bucket in `public_buckets` (comma-separated): create it if missing,
+/// then flag it anonymous public-read (read = true, list = false). This is the
+/// equivalent of MinIO's `mc anonymous set download` and lets objects be served
+/// over plain unsigned GET (e.g. media previews behind a public base URL).
+///
+/// Runs after `provision_default_buckets`, so a bucket may appear in both lists.
+/// Buckets are created on demand here too, so a public bucket need not also be
+/// listed in `default_buckets`. Invalid names are skipped; errors are non-fatal.
+pub async fn provision_public_buckets(
+    storage: &filesystem::FilesystemStorage,
+    public_buckets: &str,
+    region: &str,
+) {
+    if public_buckets.is_empty() {
+        return;
+    }
+    for bucket_name in public_buckets.split(',') {
+        let bucket_name = bucket_name.trim();
+        if bucket_name.is_empty() {
+            continue;
+        }
+        if !is_valid_bucket_name(bucket_name) {
+            tracing::warn!("Skipping invalid public bucket name: '{}'", bucket_name);
+            continue;
+        }
+        let meta = BucketMeta {
+            name: bucket_name.to_string(),
+            created_at: chrono::Utc::now()
+                .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+                .to_string(),
+            region: region.to_string(),
+            versioning: false,
+            cors_rules: None,
+            encryption_config: None,
+            public_read: true,
+            public_list: false,
+        };
+        // create_bucket returns Ok(true) for a fresh bucket (already public via
+        // meta above) and Ok(false) when it already exists. For an existing
+        // bucket, force public_read on but PRESERVE its current public_list —
+        // an operator may have enabled listing via the console, and a restart
+        // must not silently revert that.
+        match storage.create_bucket(&meta).await {
+            Ok(true) => tracing::info!("Created public bucket: {}", bucket_name),
+            Ok(false) => match storage.get_bucket_public(bucket_name).await {
+                Ok((_read, list)) => match storage.set_bucket_public(bucket_name, true, list).await
+                {
+                    Ok(()) => {
+                        tracing::info!("Enabled public-read on existing bucket: {}", bucket_name)
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to flag bucket '{}' public-read: {}", bucket_name, e)
+                    }
+                },
+                Err(e) => tracing::warn!(
+                    "Failed to read public flags for bucket '{}': {}",
+                    bucket_name,
+                    e
+                ),
+            },
+            Err(e) => tracing::warn!("Failed to create public bucket '{}': {}", bucket_name, e),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
     #[error("IO error: {0}")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -46,6 +46,7 @@ async fn start_server() -> (String, TempDir) {
         chunk_size: 10 * 1024 * 1024,
         parity_shards: 0,
         default_buckets: String::new(),
+        public_buckets: String::new(),
         max_console_body_bytes: 1024 * 1024,
     };
 
@@ -190,6 +191,7 @@ async fn start_server_with_default_buckets(default_buckets: &str) -> (String, Te
         chunk_size: 10 * 1024 * 1024,
         parity_shards: 0,
         default_buckets: default_buckets.to_string(),
+        public_buckets: String::new(),
         max_console_body_bytes: 1024 * 1024,
     };
 
@@ -266,6 +268,7 @@ async fn test_default_buckets_skip_existing() {
         chunk_size: 10 * 1024 * 1024,
         parity_shards: 0,
         default_buckets: String::new(),
+        public_buckets: String::new(),
         max_console_body_bytes: 1024 * 1024,
     };
     let state = AppState {
@@ -293,6 +296,101 @@ async fn test_default_buckets_skip_existing() {
     assert_eq!(resp.status(), 200);
     let body = resp.text().await.unwrap();
     assert!(body.contains("<Name>existing</Name>"));
+}
+
+#[tokio::test]
+async fn test_public_buckets_created_and_flagged_read_only() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path().to_str().unwrap().to_string();
+
+    let keyring = Arc::new(Keyring::load(&data_dir, None).await.unwrap());
+    let storage = FilesystemStorage::new(&data_dir, false, 10 * 1024 * 1024, 0, keyring)
+        .await
+        .unwrap();
+
+    // Provision a public bucket that does not yet exist: it is created on demand
+    // and flagged public-read (but not public-list).
+    maxio::storage::provision_public_buckets(&storage, "media", REGION).await;
+
+    assert!(storage.head_bucket("media").await.unwrap());
+    let (read, list) = storage.get_bucket_public("media").await.unwrap();
+    assert!(read, "public bucket must be anonymously readable");
+    assert!(!list, "public bucket must not be anonymously listable");
+}
+
+#[tokio::test]
+async fn test_public_buckets_flip_existing_private_bucket() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path().to_str().unwrap().to_string();
+
+    let keyring = Arc::new(Keyring::load(&data_dir, None).await.unwrap());
+    let storage = FilesystemStorage::new(&data_dir, false, 10 * 1024 * 1024, 0, keyring)
+        .await
+        .unwrap();
+
+    // A bucket created privately (e.g. via default buckets) is not public…
+    maxio::storage::provision_default_buckets(&storage, "assets", REGION).await;
+    let (read, _) = storage.get_bucket_public("assets").await.unwrap();
+    assert!(!read, "default bucket starts private");
+
+    // …and provisioning it as public flips the existing metadata, idempotently.
+    maxio::storage::provision_public_buckets(&storage, "assets", REGION).await;
+    maxio::storage::provision_public_buckets(&storage, "assets", REGION).await;
+    let (read, list) = storage.get_bucket_public("assets").await.unwrap();
+    assert!(read, "existing bucket flipped to public-read");
+    assert!(!list, "public-list stays disabled");
+}
+
+#[tokio::test]
+async fn test_public_buckets_preserve_existing_public_list() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path().to_str().unwrap().to_string();
+
+    let keyring = Arc::new(Keyring::load(&data_dir, None).await.unwrap());
+    let storage = FilesystemStorage::new(&data_dir, false, 10 * 1024 * 1024, 0, keyring)
+        .await
+        .unwrap();
+
+    // An operator created a bucket and enabled public_list (e.g. via the console).
+    maxio::storage::provision_default_buckets(&storage, "shared", REGION).await;
+    storage
+        .set_bucket_public("shared", true, true)
+        .await
+        .unwrap();
+
+    // Re-provisioning it as a public bucket must force public_read on while
+    // PRESERVING the operator-enabled public_list — not silently revert it.
+    maxio::storage::provision_public_buckets(&storage, "shared", REGION).await;
+    let (read, list) = storage.get_bucket_public("shared").await.unwrap();
+    assert!(read, "public_read forced on");
+    assert!(
+        list,
+        "operator-enabled public_list must be preserved across provisioning"
+    );
+}
+
+#[tokio::test]
+async fn test_public_buckets_skip_invalid_and_empty() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path().to_str().unwrap().to_string();
+
+    let keyring = Arc::new(Keyring::load(&data_dir, None).await.unwrap());
+    let storage = FilesystemStorage::new(&data_dir, false, 10 * 1024 * 1024, 0, keyring)
+        .await
+        .unwrap();
+
+    // Empty input is a no-op; invalid names and blank entries are skipped
+    // without panicking, and the one valid name in the list is still applied.
+    maxio::storage::provision_public_buckets(&storage, "", REGION).await;
+    maxio::storage::provision_public_buckets(&storage, "INVALID, , good-media", REGION).await;
+
+    // The invalid name was never created (head_bucket rejects the bad name too).
+    assert!(storage.head_bucket("INVALID").await.is_err());
+    // The valid name was created and flagged public-read.
+    assert!(storage.head_bucket("good-media").await.unwrap());
+    let (read, list) = storage.get_bucket_public("good-media").await.unwrap();
+    assert!(read);
+    assert!(!list);
 }
 
 #[tokio::test]
@@ -2977,6 +3075,7 @@ async fn start_server_ec() -> (String, TempDir) {
         chunk_size: 1024,
         parity_shards: 0,
         default_buckets: String::new(),
+        public_buckets: String::new(),
         max_console_body_bytes: 1024 * 1024,
     };
 
@@ -3434,6 +3533,7 @@ async fn start_server_parity(parity_shards: u32) -> (String, TempDir) {
         chunk_size: 100,
         parity_shards,
         default_buckets: String::new(),
+        public_buckets: String::new(),
         max_console_body_bytes: 1024 * 1024,
     };
 
@@ -5212,6 +5312,15 @@ async fn test_public_bucket_rejects_mutating_query() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 403);
+
+    // Anonymous GET ?uploadId routes to multipart list_parts — a distinct
+    // surface from object read — so it stays blocked even on a public_read bucket.
+    let resp = client()
+        .get(&format!("{}/pub-mut/some-key?uploadId=deadbeef", base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 403);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -6108,6 +6217,7 @@ async fn start_server_ec_parity(chunk_size: u64, parity_shards: u32) -> (String,
         chunk_size,
         parity_shards,
         default_buckets: String::new(),
+        public_buckets: String::new(),
         max_console_body_bytes: 1024 * 1024,
     };
 


### PR DESCRIPTION
Closes #18.

## What

Adds **`MAXIO_PUBLIC_BUCKETS`** (env / `--public-buckets`, alias `MINIO_PUBLIC_BUCKETS`): a comma-separated list of buckets that, on boot, are created if missing and flagged **public-read** (`read = true`, `list = false`) — the single-binary equivalent of MinIO's `mc anonymous set download`. It mirrors the existing `MAXIO_DEFAULT_BUCKETS` and runs immediately after it, through the same provisioning path.

## Why

See #18: MaxIO already supports anonymous public-read per bucket, but only via the interactive console — there's no startup option, and no `PutBucketPolicy` for `mc anonymous` to target. This closes that gap for the common "serve public media over unsigned GET from an unattended boot" use case (e.g. a `docker compose` stack with no human to click through the console).

## Behavior

- Creates listed buckets on demand, so a public bucket need not also appear in `MAXIO_DEFAULT_BUCKETS`.
- For a bucket that **already exists**, forces `public_read` on while **preserving** its current `public_list` — a restart never silently reverts a console-set listing. Only the read flag is forced.
- Invalid names are skipped; all errors are non-fatal (logged), same as `provision_default_buckets`.

## Included hardening

While making public-read a first-class startup option, I also tightened the anonymous public-read bypass: `?uploadId` and `?partNumber` now go through the bypass deny-list, so an anonymous GET on a `public_read` bucket can no longer reach multipart `list_parts` and enumerate in-progress upload metadata (a surface distinct from object read). Without this, exposing a bucket via `MAXIO_PUBLIC_BUCKETS` would also expose multipart listing.

## Config

| Variable | Flag | Default | Description |
|---|---|---|---|
| `MAXIO_PUBLIC_BUCKETS` | `--public-buckets` | _(none)_ | Comma-separated buckets to expose as anonymous public-read, created on boot if missing (alias `MINIO_PUBLIC_BUCKETS`) |

## Tests

New integration coverage: create-and-flag (`read=true`/`list=false`), flip-existing-private, **preserve operator-set `public_list`**, invalid/empty input, and the anonymous `?uploadId` bypass block.

Local checks matching CI: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean. `cargo test` is green except the two pre-existing `test_folder_marker_with_children` / `test_multipart_sse_c_part_key_mismatch_rejected` cases, which reproduce on a clean `main` on Windows and are unrelated to this change.

## Notes

- Follows `CLAUDE.md` conventions (`MaxIO` in prose, `MAXIO_` env prefix, MinIO-aliased for parity with the other vars).
- README config table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
